### PR TITLE
Sync CV to new Platform Engineer resume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ yarn-error.log*
 *.log
 *.pem
 public/chunks/
+.vercel
+.env*
+.gstack/

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -112,32 +112,38 @@ const workingWithMe = {
 
 const technicalSkills = [
   {
-    category: "PLATFORM SKILLS",
-    items: [
-      "AWS",
-      "GCP",
-      "Azure",
-      "Terraform",
-      "Kubernetes",
-      "Docker",
-      "Ansible",
-      "GitLab CI",
-    ],
+    category: "CLOUD PROVIDERS",
+    items: ["AWS", "GCP", "Microsoft Azure", "DigitalOcean"],
     icon: CloudIcon,
   },
   {
-    category: "TECHNICAL SKILLS",
-    items: [
-      "Infrastructure as Code",
-      "CI/CD Pipelines",
-      "Monitoring & Observability",
-      "Container Orchestration",
-    ],
+    category: "INFRASTRUCTURE",
+    items: ["Docker", "Kubernetes", "Terraform", "Ansible"],
+    icon: ServerStackIcon,
+  },
+  {
+    category: "CI/CD TOOLING",
+    items: ["GitHub Actions", "GitLab CI", "Jenkins", "CloudBuild / CloudRun"],
     icon: CodeIcon,
   },
   {
-    category: "DATABASES & SERVERS",
-    items: ["PostgreSQL", "MySQL", "MongoDB", "Nginx", "Apache"],
+    category: "MONITORING",
+    items: ["Prometheus", "Grafana", "Loki", "Tempo"],
+    icon: Wrench01Icon,
+  },
+  {
+    category: "LINUX, SERVERS & DATABASES",
+    items: [
+      "RHEL / CentOS",
+      "Ubuntu Server",
+      "Debian",
+      "FreeBSD",
+      "Nginx",
+      "Apache",
+      "PostgreSQL",
+      "MySQL",
+      "MongoDB",
+    ],
     icon: Database01Icon,
   },
 ];
@@ -230,7 +236,7 @@ export default function About() {
           >
             <Image
               src="/assets/images/me-urban-large.png"
-              alt="Carlos Romero - Cloud Engineer"
+              alt="Carlos Romero - Platform Engineer"
               fill
               className="object-cover"
               priority
@@ -245,7 +251,7 @@ export default function About() {
           >
             <Image
               src="/assets/images/me-urban-large.png"
-              alt="Carlos Romero - Cloud Engineer"
+              alt="Carlos Romero - Platform Engineer"
               fill
               className="object-cover object-center"
               priority
@@ -302,7 +308,7 @@ export default function About() {
               </motion.div>
             </motion.div>
 
-            {/* Cloud Engineer in Geometric Box */}
+            {/* Platform Engineer in Geometric Box */}
             {hiComplete && (
               <motion.div
                 initial={{ opacity: 0, x: -50 }}
@@ -311,7 +317,7 @@ export default function About() {
                 className="bg-black p-4 md:p-6 transform -rotate-1 mb-12 max-w-fit"
               >
                 <h2 className="text-2xl md:text-4xl font-black text-white tracking-tight glitch-hover">
-                  CLOUD ENGINEER
+                  PLATFORM ENGINEER
                 </h2>
               </motion.div>
             )}
@@ -354,7 +360,7 @@ export default function About() {
             {/* Brutalist Download Button */}
             {hiComplete && (
               <motion.a
-                href="https://33vyi7jhxz3mujt2.public.blob.vercel-storage.com/CarlosRomero-CloudEngineer.pdf"
+                href="https://33vyi7jhxz3mujt2.public.blob.vercel-storage.com/CarlosRomero-PlatformEngineer.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
                 initial={{ opacity: 0, scale: 0.8, rotate: -5 }}
@@ -678,7 +684,7 @@ export default function About() {
                 and technical expertise.
               </p>
               <motion.a
-                href="https://33vyi7jhxz3mujt2.public.blob.vercel-storage.com/CarlosRomero-CloudEngineer.pdf"
+                href="https://33vyi7jhxz3mujt2.public.blob.vercel-storage.com/CarlosRomero-PlatformEngineer.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
                 whileHover={{ scale: 1.1, rotate: 0 }}

--- a/app/api/stack/route.ts
+++ b/app/api/stack/route.ts
@@ -7,13 +7,14 @@ export async function GET(request: NextRequest) {
   const data = {
     message: "Don't try this in production (or do, I'm not your dad) 🤷‍♂️",
     author: "Carlos Romero",
-    role: "DevOps Engineer & Platform Architect",
+    role: "Platform Engineer",
     motto: "Scalable Infrastructure. Reliable Systems.",
     tech_stack: {
       cloud_platforms: [
         "AWS ☁️",
-        "Google Cloud Platform 🌤️", 
-        "Microsoft Azure 🌩️"
+        "Google Cloud Platform 🌤️",
+        "Microsoft Azure 🌩️",
+        "DigitalOcean 🌊"
       ],
       infrastructure: [
         "Terraform 🏗️",
@@ -35,8 +36,8 @@ export async function GET(request: NextRequest) {
       monitoring: [
         "Prometheus 📊",
         "Grafana 📈",
-        "ELK Stack 🔍",
-        "Airflow 🌊"
+        "Loki 🔍",
+        "Tempo ⏱️"
       ],
       databases: [
         "PostgreSQL 🐘",

--- a/app/api/whoami/route.ts
+++ b/app/api/whoami/route.ts
@@ -6,9 +6,9 @@ export async function GET(request: NextRequest) {
 
   const data = {
     name: "Carlos Romero",
-    role: "DevOps Engineer & Platform Architect",
+    role: "Platform Engineer",
     location: "Building the future, one YAML file at a time",
-    experience: "8+ years turning coffee into infrastructure",
+    experience: "6+ years turning coffee into infrastructure",
     specialties: [
       "Making servers behave (mostly)",
       "Kubernetes whispering",

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -60,7 +60,7 @@ export default function Contact() {
       id: "exp",
       type: "bot",
       content:
-        "I have over 8 years of experience in DevOps and cloud engineering. I've worked with major companies in healthcare, banking, and technology sectors. Currently, I'm focusing on platform engineering at AI MEDICA.",
+        "I have over 6 years of experience in DevOps and cloud engineering. I've worked with major companies in healthcare, banking, and technology sectors. Currently, I'm focusing on platform engineering at AI MEDICA.",
     },
     "What services do you offer?": {
       id: "services",

--- a/components/loading-skeleton.tsx
+++ b/components/loading-skeleton.tsx
@@ -93,7 +93,7 @@ export function LoadingSkeleton() {
           {/* Skills Section */}
           <div className="lg:col-span-3 space-y-6">
             <Skeleton className="h-8 w-48" />
-            {[1, 2, 3, 4, 5, 6].map((i) => (
+            {[1, 2, 3, 4, 5].map((i) => (
               <Skeleton key={i} className="h-[120px] rounded-lg" />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- Uploaded the new resume (`CarlosRomero_Platform_Engineer.pdf`) to the `worksbycarlos` Vercel Blob store and repointed both DOWNLOAD RESUME buttons at it.
- Retitled the /about hero from CLOUD ENGINEER to PLATFORM ENGINEER to match the resume.
- Rebuilt the skills cards from the resume's Core Technologies, and corrected the stale "8 years" / "DevOps Engineer & Platform Architect" strings in the JSON API routes and /contact.

## Changes
- `app/about/page.tsx` — hero title + image alts, both PDF hrefs, `technicalSkills` regrouped into Cloud Providers / Infrastructure / CI/CD Tooling / Monitoring / Linux, Servers & Databases (adds DigitalOcean, RHEL/CentOS, Ubuntu Server, Debian, FreeBSD, GitHub Actions, Jenkins, CloudBuild/CloudRun, Prometheus, Grafana, Loki, Tempo)
- `app/api/whoami/route.ts` — role to Platform Engineer, 8+ to 6+ years
- `app/api/stack/route.ts` — role, added DigitalOcean, monitoring ELK/Airflow to Loki/Tempo
- `app/contact/page.tsx` — chatbot bio "over 8 years" to "over 6 years"
- `components/loading-skeleton.tsx` — about-page skeleton now 5 skill cards to match
- `.gitignore` — ignore `.vercel`, `.env*`, `.gstack/`

New blob URL: https://33vyi7jhxz3mujt2.public.blob.vercel-storage.com/CarlosRomero-PlatformEngineer.pdf (old `CarlosRomero-CloudEngineer.pdf` left in place, unreferenced).

## Testing
- `npx tsc --noEmit` clean, `npm run build` clean (13/13 static pages).
- Ran the production build locally and drove /about in a headless browser: hero renders PLATFORM ENGINEER, both PDF hrefs resolve to the new file, all 5 skill cards render, no console errors.
- `curl` on the new blob URL returns 200 / `application/pdf` / 3,860,922 bytes.
- `/api/whoami` and `/api/stack` verified to return the updated role and stack.